### PR TITLE
fix: Import errors in auth0_server_python

### DIFF
--- a/packages/auth0_server_python/README.md
+++ b/packages/auth0_server_python/README.md
@@ -1,6 +1,6 @@
 The Auth0 Server Python SDK is a library for implementing user authentication in Python applications.
 
-![PyPI](https://img.shields.io/pypi/v/auth0-server-python) ![Downloads](https://img.shields.io/pypi/dw/auth0-server-python) [![License](https://img.shields.io/:license-MIT-blue.svg?style=flat)](https://opensource.org/licenses/MIT) [![Codecov](https://img.shields.io/codecov/c/github/auth0/auth0-server-python)](https://codecov.io/gh/auth0/auth0-server-python) [![CI](https://github.com/auth0/auth0-server-python/actions/workflows/ci.yml/badge.svg)](https://github.com/auth0/auth0-server-python/actions)
+![PyPI](https://img.shields.io/pypi/v/auth0-server-python) ![Downloads](https://img.shields.io/pypi/dw/auth0-server-python) [![License](https://img.shields.io/:license-MIT-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 
 📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💬 [Feedback](#feedback)
 
@@ -29,7 +29,7 @@ Create an instance of the Auth0 client. This instance will be imported and used 
 
 
 ```python
-from auth0_server_python import ServerClient
+from auth0_server_python.auth_server.server_client import ServerClient
 
 auth0 = ServerClient(
     domain='<AUTH0_DOMAIN>',
@@ -109,7 +109,7 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 - [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 - [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
-- [This repo's contribution guide](./CONTRIBUTING.md)
+- [This repo's contribution guide](./../../CONTRIBUTING.md)
 
 ### Raise an issue
 

--- a/packages/auth0_server_python/pyproject.toml
+++ b/packages/auth0_server_python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth0-server-python"
-version = "1.0.0.b2"
+version = "1.0.0.b3"
 description = "Auth0 server-side Python SDK"
 readme = "README.md"
 authors = ["Auth0 <support@okta.com>"]
@@ -17,7 +17,6 @@ pyjwt = ">=2.8.0"
 authlib = "^1.2"
 httpx = "^0.28.1"
 pydantic = "^2.10.6"
-fastapi = "^0.115.11"
 jwcrypto = "^1.5.6"
 
 [tool.poetry.group.dev.dependencies]

--- a/packages/auth0_server_python/src/auth0_server_python/auth_server/server_client.py
+++ b/packages/auth0_server_python/src/auth0_server_python/auth_server/server_client.py
@@ -16,7 +16,7 @@ import httpx
 
 from pydantic import BaseModel, ValidationError
 
-from error import (
+from auth0_server_python.error import (
     MissingTransactionError, 
     ApiError, 
     MissingRequiredArgumentError,
@@ -28,7 +28,7 @@ from error import (
     AccessTokenForConnectionErrorCode
     
 )
-from auth_types import (
+from auth0_server_python.auth_types import (
     StateData, 
     TransactionData, 
     UserClaims, 
@@ -37,7 +37,7 @@ from auth_types import (
     StartInteractiveLoginOptions,
     LogoutOptions
 )
-from utils import PKCE, State, URL
+from auth0_server_python.utils import PKCE, State, URL
 
 
 # Generic type for store options

--- a/packages/auth0_server_python/src/auth0_server_python/encryption/encrypt.py
+++ b/packages/auth0_server_python/src/auth0_server_python/encryption/encrypt.py
@@ -12,7 +12,7 @@ ENC = 'A256CBC-HS512'
 ALG = 'dir'
 DIGEST = hashes.SHA256()
 BYTE_LENGTH = 64
-ENCRYPTION_INFO = b'Auth0 Generated ryption'
+ENCRYPTION_INFO = b'Auth0 Generated Encryption'
 
 
 

--- a/packages/auth0_server_python/src/auth0_server_python/store/abstract.py
+++ b/packages/auth0_server_python/src/auth0_server_python/store/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar, Optional, Dict, Any
 
-from encryption import encrypt, decrypt
+from auth0_server_python.encryption import encrypt, decrypt
 
 T = TypeVar('T')  # Generic type for the data stored
 


### PR DESCRIPTION
### Changes

- [fix: Parent folder added to import paths ](https://github.com/auth0/auth0-server-python/pull/8) ([mustafadeel](https://github.com/mustafadeel))

- Fixing broken links in the Readme.MD (auth0_server_python)


### Testing
After the change I am no longer getting the error.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
