### PR TITLE
fix(router): allow forward all request query params on login and filter sensitive ones

### DIFF
--- a/packages/auth0_fastapi/src/auth0_fastapi/server/routes.py
+++ b/packages/auth0_fastapi/src/auth0_fastapi/server/routes.py
@@ -1,9 +1,10 @@
+from ..util import to_safe_redirect, create_route_url, merge_set_cookie_headers
+from ..util import to_safe_redirect, create_route_url
 from fastapi import APIRouter, Request, Response, HTTPException, Depends, Query
 from fastapi.responses import RedirectResponse
 from typing import Optional
 from ..auth.auth_client import AuthClient
 from ..config import Auth0Config
-from ..util import to_safe_redirect, create_route_url
 
 router = APIRouter()
 
@@ -34,8 +35,11 @@ def register_auth_routes(router: APIRouter, config: Auth0Config):
             """
 
             return_to: Optional[str] = request.query_params.get("returnTo")
+            authorization_params = {k: v for k, v in request.query_params.items() if k not in [
+                "returnTo"]}
             auth_url = await auth_client.start_login(
                 app_state={"returnTo": return_to} if return_to else None,
+                authorization_params=authorization_params,
                 store_options={"response": response}
             )
 

--- a/packages/auth0_server_python/src/auth0_server_python/auth_server/server_client.py
+++ b/packages/auth0_server_python/src/auth0_server_python/auth_server/server_client.py
@@ -12,13 +12,13 @@ import jwt
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.integrations.base_client.errors import OAuthError
-import httpx 
+import httpx
 
 from pydantic import BaseModel, ValidationError
 
 from auth0_server_python.error import (
-    MissingTransactionError, 
-    ApiError, 
+    MissingTransactionError,
+    ApiError,
     MissingRequiredArgumentError,
     BackchannelLogoutError,
     AccessTokenError,
@@ -26,12 +26,12 @@ from auth0_server_python.error import (
     StartLinkUserError,
     AccessTokenErrorCode,
     AccessTokenForConnectionErrorCode
-    
+
 )
 from auth0_server_python.auth_types import (
-    StateData, 
-    TransactionData, 
-    UserClaims, 
+    StateData,
+    TransactionData,
+    UserClaims,
     TokenSet,
     LogoutTokenClaims,
     StartInteractiveLoginOptions,
@@ -42,13 +42,16 @@ from auth0_server_python.utils import PKCE, State, URL
 
 # Generic type for store options
 TStoreOptions = TypeVar('TStoreOptions')
+INTERNAL_AUTHORIZE_PARAMS = ["client_id", "redirect_uri", "response_type",
+                             "code_challenge", "code_challenge_method", "state", "nonce"]
+
 
 class ServerClient(Generic[TStoreOptions]):
     """
     Main client for Auth0 server SDK. Handles authentication flows, session management,
     and token operations using Authlib for OIDC functionality.
     """
-    
+
     def __init__(
         self,
         domain: str,
@@ -56,8 +59,8 @@ class ServerClient(Generic[TStoreOptions]):
         client_secret: str,
         redirect_uri: Optional[str] = None,
         secret: str = None,
-        transaction_store = None,
-        state_store = None,
+        transaction_store=None,
+        state_store=None,
         transaction_identifier: str = "_a0_tx",
         state_identifier: str = "_a0_session",
         authorization_params: Optional[Dict[str, Any]] = None,
@@ -65,7 +68,7 @@ class ServerClient(Generic[TStoreOptions]):
     ):
         """
         Initialize the Auth0 server client.
-        
+
         Args:
             domain: Auth0 domain (e.g., 'your-tenant.auth0.com')
             client_id: Auth0 client ID
@@ -80,7 +83,7 @@ class ServerClient(Generic[TStoreOptions]):
         """
         if not secret:
             raise MissingRequiredArgumentError("secret")
-            
+
         # Store configuration
         self._domain = domain
         self._client_id = client_id
@@ -88,13 +91,13 @@ class ServerClient(Generic[TStoreOptions]):
         self._redirect_uri = redirect_uri
         self._default_authorization_params = authorization_params or {}
         self._pushed_authorization_requests = pushed_authorization_requests  # store the flag
-        
+
         # Initialize stores
         self._transaction_store = transaction_store
         self._state_store = state_store
         self._transaction_identifier = transaction_identifier
         self._state_identifier = state_identifier
-        
+
         # Initialize OAuth client
         self._oauth = AsyncOAuth2Client(
             client_id=client_id,
@@ -108,7 +111,6 @@ class ServerClient(Generic[TStoreOptions]):
             response.raise_for_status()
             return response.json()
 
-    
     async def start_interactive_login(
         self,
         options: Optional[StartInteractiveLoginOptions] = None,
@@ -116,40 +118,43 @@ class ServerClient(Generic[TStoreOptions]):
     ) -> str:
         """
         Starts the interactive login process and returns a URL to redirect to.
-        
+
         Args:
             options: Configuration options for the login process
-            
+
         Returns:
             Authorization URL to redirect the user to
         """
         options = options or StartInteractiveLoginOptions()
-        
+
         # Get effective authorization params (merge defaults with provided ones)
         auth_params = dict(self._default_authorization_params)
         if options.authorization_params:
-            auth_params.update(options.authorization_params)
-            
+            auth_params.update(
+                {k: v for k, v in options.authorization_params.items(
+                ) if k not in INTERNAL_AUTHORIZE_PARAMS}
+            )
+
         # Ensure we have a redirect_uri
         if "redirect_uri" not in auth_params and not self._redirect_uri:
             raise MissingRequiredArgumentError("redirect_uri")
-        
+
         # Use the default redirect_uri if none is specified
         if "redirect_uri" not in auth_params and self._redirect_uri:
             auth_params["redirect_uri"] = self._redirect_uri
-        
+
         # Generate PKCE code verifier and challenge
         code_verifier = PKCE.generate_code_verifier()
         code_challenge = PKCE.generate_code_challenge(code_verifier)
-        
+
         # Add PKCE parameters to the authorization request
         auth_params["code_challenge"] = code_challenge
         auth_params["code_challenge_method"] = "S256"
-        
+
         # State parameter to prevent CSRF
         state = PKCE.generate_random_string(32)
         auth_params["state"] = state
-        
+
         # Build the transaction data to store
         transaction_data = TransactionData(
             code_verifier=code_verifier,
@@ -158,20 +163,23 @@ class ServerClient(Generic[TStoreOptions]):
 
         # Store the transaction data
         await self._transaction_store.set(
-            f"{self._transaction_identifier}:{state}", 
+            f"{self._transaction_identifier}:{state}",
             transaction_data,
             options=store_options
         )
         try:
             self._oauth.metadata = await self._fetch_oidc_metadata(self._domain)
         except Exception as e:
-            raise ApiError("metadata_error", "Failed to fetch OIDC metadata", e)       
+            raise ApiError("metadata_error",
+                           "Failed to fetch OIDC metadata", e)
         # If PAR is enabled, use the PAR endpoint
         if self._pushed_authorization_requests:
-            par_endpoint = self._oauth.metadata.get("pushed_authorization_request_endpoint")
+            par_endpoint = self._oauth.metadata.get(
+                "pushed_authorization_request_endpoint")
             if not par_endpoint:
-                raise ApiError("configuration_error", "PAR is enabled but pushed_authorization_request_endpoint is missing in metadata")
-            
+                raise ApiError(
+                    "configuration_error", "PAR is enabled but pushed_authorization_request_endpoint is missing in metadata")
+
             auth_params["client_id"] = self._client_id
             # Post the auth_params to the PAR endpoint
             async with httpx.AsyncClient() as client:
@@ -184,71 +192,76 @@ class ServerClient(Generic[TStoreOptions]):
                     error_data = par_response.json()
                     raise ApiError(
                         error_data.get("error", "par_error"),
-                        error_data.get("error_description", "Failed to obtain request_uri from PAR endpoint")
+                        error_data.get(
+                            "error_description", "Failed to obtain request_uri from PAR endpoint")
                     )
                 par_data = par_response.json()
                 request_uri = par_data.get("request_uri")
                 if not request_uri:
-                    raise ApiError("par_error", "No request_uri returned from PAR endpoint")
-            
+                    raise ApiError(
+                        "par_error", "No request_uri returned from PAR endpoint")
+
             auth_endpoint = self._oauth.metadata.get("authorization_endpoint")
             final_url = f"{auth_endpoint}?request_uri={request_uri}&response_type={auth_params['response_type']}&client_id={self._client_id}"
             return final_url
         else:
             if "authorization_endpoint" not in self._oauth.metadata:
-                raise ApiError("configuration_error", "Authorization endpoint missing in OIDC metadata")
+                raise ApiError("configuration_error",
+                               "Authorization endpoint missing in OIDC metadata")
 
             authorization_endpoint = self._oauth.metadata["authorization_endpoint"]
 
             try:
-                auth_url, state = self._oauth.create_authorization_url(authorization_endpoint, **auth_params)
+                auth_url, state = self._oauth.create_authorization_url(
+                    authorization_endpoint, **auth_params)
             except Exception as e:
-                raise ApiError("authorization_url_error", "Failed to create authorization URL", e)
+                raise ApiError("authorization_url_error",
+                               "Failed to create authorization URL", e)
 
             return auth_url
-    
+
     async def complete_interactive_login(
-        self, 
+        self,
         url: str,
         store_options: dict = None
     ) -> Dict[str, Any]:
         """
         Completes the login process after user is redirected back.
-        
+
         Args:
             url: The full callback URL including query parameters
             store_options: Options to pass to the state store
-            
+
         Returns:
             Dictionary containing session data and app state
         """
         # Parse the URL to get query parameters
         parsed_url = urlparse(url)
         query_params = parse_qs(parsed_url.query)
-        
+
         # Get state parameter from the URL
         state = query_params.get("state", [""])[0]
         if not state:
             raise MissingRequiredArgumentError("state")
-        
+
         # Retrieve the transaction data using the state
         transaction_identifier = f"{self._transaction_identifier}:{state}"
         transaction_data = await self._transaction_store.get(transaction_identifier, options=store_options)
-        
+
         if not transaction_data:
             raise MissingTransactionError()
-        
+
         # Check for error response from Auth0
         if "error" in query_params:
             error = query_params.get("error", [""])[0]
             error_description = query_params.get("error_description", [""])[0]
             raise ApiError(error, error_description)
-        
+
         # Get the authorization code from the URL
         code = query_params.get("code", [""])[0]
         if not code:
             raise MissingRequiredArgumentError("code")
-        
+
         if not self._oauth.metadata or "token_endpoint" not in self._oauth.metadata:
             self._oauth.metadata = await self._fetch_oidc_metadata(self._domain)
 
@@ -263,57 +276,62 @@ class ServerClient(Generic[TStoreOptions]):
             )
         except OAuthError as e:
             # Raise a custom error (or handle it as appropriate)
-            raise ApiError("token_error", f"Token exchange failed: {str(e)}", e)  
-        
+            raise ApiError(
+                "token_error", f"Token exchange failed: {str(e)}", e)
+
        # Use the userinfo field from the token_response for user claims
         user_info = token_response.get("userinfo")
         user_claims = None
         if user_info:
             user_claims = UserClaims.parse_obj(user_info)
         else:
-            id_token = token_response.get("id_token")            
-            if id_token:              
-                claims = jwt.decode(id_token, options={"verify_signature": False})
+            id_token = token_response.get("id_token")
+            if id_token:
+                claims = jwt.decode(id_token, options={
+                                    "verify_signature": False})
                 user_claims = UserClaims.parse_obj(claims)
-        
+
         # Build a token set using the token response data
         token_set = TokenSet(
             audience=token_response.get("audience", "default"),
             access_token=token_response.get("access_token", ""),
             scope=token_response.get("scope", ""),
-            expires_at=int(time.time()) + token_response.get("expires_in", 3600)
+            expires_at=int(time.time()) +
+            token_response.get("expires_in", 3600)
         )
-        
+
         # Generate a session id (sid) from token_response or transaction data, or create a new one
-        sid = user_info.get("sid") if user_info and "sid" in user_info else PKCE.generate_random_string(32)
-        
+        sid = user_info.get(
+            "sid") if user_info and "sid" in user_info else PKCE.generate_random_string(32)
+
         # Construct state data to represent the session
         state_data = StateData(
             user=user_claims,
             id_token=token_response.get("id_token"),
-            refresh_token=token_response.get("refresh_token"),  # might be None if not provided
+            # might be None if not provided
+            refresh_token=token_response.get("refresh_token"),
             token_sets=[token_set],
             internal={
                 "sid": sid,
                 "created_at": int(time.time())
             }
         )
-        
+
         # Store the state data in the state store using store_options (Response required)
         await self._state_store.set(self._state_identifier, state_data, options=store_options)
-        
+
         # Clean up transaction data after successful login
         await self._transaction_store.delete(transaction_identifier, options=store_options)
-        
+
         result = {"state_data": state_data.dict()}
         if transaction_data.app_state:
             result["app_state"] = transaction_data.app_state
-            
-        #For RAR
+
+        # For RAR
         authorization_details = token_response.get("authorization_details")
         if authorization_details:
             result["authorization_details"] = authorization_details
-            
+
         return result
 
     async def start_link_user(
@@ -323,25 +341,25 @@ class ServerClient(Generic[TStoreOptions]):
     ):
         """
         Starts the user linking process, and returns a URL to redirect the user-agent to.
-        
+
         Args:
             options: Options used to configure the user linking process.
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             URL to redirect the user to for authentication.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
-        
+
         if not state_data or not state_data.get("id_token"):
             raise StartLinkUserError(
                 "Unable to start the user linking process without a logged in user. Ensure to login using the SDK before starting the user linking process."
             )
-        
+
         # Generate PKCE and state for security
         code_verifier = PKCE.generate_code_verifier()
         state = PKCE.generate_random_string(32)
-        
+
         # Build the URL for user linking
         link_user_url = await self._build_link_user_url(
             connection=options.get("connection"),
@@ -351,21 +369,21 @@ class ServerClient(Generic[TStoreOptions]):
             state=state,
             authorization_params=options.get("authorization_params")
         )
-        
+
         # Store transaction data
         transaction_data = TransactionData(
             code_verifier=code_verifier,
             app_state=options.get("app_state")
         )
-        
+
         await self._transaction_store.set(
-            f"{self._transaction_identifier}:{state}", 
+            f"{self._transaction_identifier}:{state}",
             transaction_data,
             options=store_options
         )
-        
+
         return link_user_url
-    
+
     async def complete_link_user(
         self,
         url: str,
@@ -373,23 +391,23 @@ class ServerClient(Generic[TStoreOptions]):
     ) -> Dict[str, Any]:
         """
         Completes the user linking process.
-        
+
         Args:
             url: The URL from which the query params should be extracted
             store_options: Optional options for the stores
-            
+
         Returns:
             Dictionary containing the original app state
         """
 
         # We can reuse the interactive login completion since the flow is similar
         result = await self.complete_interactive_login(url, store_options)
-        
+
         # Return just the app state as specified
         return {
             "app_state": result.get("app_state")
         }
-    
+
     async def start_unlink_user(
         self,
         options,
@@ -397,25 +415,25 @@ class ServerClient(Generic[TStoreOptions]):
     ):
         """
         Starts the user unlinking process, and returns a URL to redirect the user-agent to.
-        
+
         Args:
             options: Options used to configure the user unlinking process.
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             URL to redirect the user to for authentication.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
-        
+
         if not state_data or not state_data.get("id_token"):
             raise StartLinkUserError(
                 "Unable to start the user linking process without a logged in user. Ensure to login using the SDK before starting the user linking process."
             )
-        
+
         # Generate PKCE and state for security
         code_verifier = PKCE.generate_code_verifier()
         state = PKCE.generate_random_string(32)
-        
+
         # Build the URL for user linking
         link_user_url = await self._build_unlink_user_url(
             connection=options.get("connection"),
@@ -424,21 +442,21 @@ class ServerClient(Generic[TStoreOptions]):
             state=state,
             authorization_params=options.get("authorization_params")
         )
-        
+
         # Store transaction data
         transaction_data = TransactionData(
             code_verifier=code_verifier,
             app_state=options.get("app_state")
         )
-        
+
         await self._transaction_store.set(
-            f"{self._transaction_identifier}:{state}", 
+            f"{self._transaction_identifier}:{state}",
             transaction_data,
             options=store_options
         )
-        
+
         return link_user_url
-    
+
     async def complete_unlink_user(
         self,
         url: str,
@@ -446,25 +464,23 @@ class ServerClient(Generic[TStoreOptions]):
     ) -> Dict[str, Any]:
         """
         Completes the user unlinking process.
-        
+
         Args:
             url: The URL from which the query params should be extracted
             store_options: Optional options for the stores
-            
+
         Returns:
             Dictionary containing the original app state
         """
 
         # We can reuse the interactive login completion since the flow is similar
         result = await self.complete_interactive_login(url, store_options)
-        
+
         # Return just the app state as specified
         return {
             "app_state": result.get("app_state")
         }
-        
 
-    
     async def login_backchannel(
         self,
         options: Dict[str, Any],
@@ -472,18 +488,18 @@ class ServerClient(Generic[TStoreOptions]):
     ) -> Dict[str, Any]:
         """
         Logs in using Client-Initiated Backchannel Authentication.
-        
+
         Note:
-            Using Client-Initiated Backchannel Authentication requires the feature 
+            Using Client-Initiated Backchannel Authentication requires the feature
             to be enabled in the Auth0 dashboard.
-        
+
         See:
             https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow
-        
+
         Args:
             options: Options used to configure the backchannel login process.
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             A dictionary containing the authorizationDetails (when RAR was used).
         """
@@ -492,10 +508,11 @@ class ServerClient(Generic[TStoreOptions]):
             "login_hint": options.get("login_hint"),
             "authorization_params": options.get("authorization_params"),
         })
-        
+
         existing_state_data = await self._state_store.get(self._state_identifier, store_options)
-        
-        audience = self._default_authorization_params.get("audience", "default")
+
+        audience = self._default_authorization_params.get(
+            "audience", "default")
 
         state_data = State.update_state_data(
             audience,
@@ -513,15 +530,15 @@ class ServerClient(Generic[TStoreOptions]):
     async def get_user(self, store_options: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         """
         Retrieves the user from the store, or None if no user found.
-        
+
         Args:
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             The user, or None if no user found in the store.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
-        
+
         if state_data:
             if hasattr(state_data, "dict") and callable(state_data.dict):
                 state_data = state_data.dict()
@@ -531,45 +548,45 @@ class ServerClient(Generic[TStoreOptions]):
     async def get_session(self, store_options: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         """
         Retrieve the user session from the store, or None if no session found.
-        
+
         Args:
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             The session, or None if no session found in the store.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
-        
+
         if state_data:
             if hasattr(state_data, "dict") and callable(state_data.dict):
                 state_data = state_data.dict()
-            session_data = {k: v for k, v in state_data.items() if k != "internal"}
+            session_data = {k: v for k, v in state_data.items()
+                            if k != "internal"}
             return session_data
         return None
 
     async def get_access_token(self, store_options: Optional[Dict[str, Any]] = None) -> str:
         """
-        Retrieves the access token from the store, or calls Auth0 when the access token 
+        Retrieves the access token from the store, or calls Auth0 when the access token
         is expired and a refresh token is available in the store.
         Also updates the store when a new token was retrieved from Auth0.
-        
+
         Args:
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             The access token, retrieved from the store or Auth0.
-            
+
         Raises:
             AccessTokenError: If the token is expired and no refresh token is available.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
-        
+
         # Get audience and scope from options or use defaults
         auth_params = self._default_authorization_params or {}
         audience = auth_params.get("audience", "default")
         scope = auth_params.get("scope")
 
-        
         if state_data and hasattr(state_data, "dict") and callable(state_data.dict):
             state_data_dict = state_data.dict()
         else:
@@ -582,31 +599,32 @@ class ServerClient(Generic[TStoreOptions]):
                 if ts.get("audience") == audience and (not scope or ts.get("scope") == scope):
                     token_set = ts
                     break
-        
+
         # If token is valid, return it
         if token_set and token_set.get("expires_at", 0) > time.time():
             return token_set["access_token"]
-        
+
         # Check for refresh token
         if not state_data_dict or not state_data_dict.get("refresh_token"):
             raise AccessTokenError(
                 AccessTokenErrorCode.MISSING_REFRESH_TOKEN,
                 "The access token has expired and a refresh token was not provided. The user needs to re-authenticate."
             )
-        
+
         # Get new token with refresh token
         try:
             token_endpoint_response = await self.get_token_by_refresh_token({
                 "refresh_token": state_data_dict["refresh_token"]
             })
-            
+
             # Update state data with new token
             existing_state_data = await self._state_store.get(self._state_identifier, store_options)
-            updated_state_data = State.update_state_data(audience, existing_state_data, token_endpoint_response)
-            
+            updated_state_data = State.update_state_data(
+                audience, existing_state_data, token_endpoint_response)
+
             # Store updated state
             await self._state_store.set(self._state_identifier, updated_state_data, options=store_options)
-            
+
             return token_endpoint_response["access_token"]
         except Exception as e:
             if isinstance(e, AccessTokenError):
@@ -623,21 +641,21 @@ class ServerClient(Generic[TStoreOptions]):
     ) -> str:
         """
         Retrieves an access token for a connection.
-        
+
         This method attempts to obtain an access token for a specified connection.
         It first checks if a refresh token exists in the store.
         If no refresh token is found, it throws an `AccessTokenForConnectionError` indicating
         that the refresh token was not found.
-        
+
         Args:
             options: Options for retrieving an access token for a connection.
             store_options: Optional options used to pass to the Transaction and State Store.
-            
+
         Returns:
             The access token for the connection
-            
+
         Raises:
-            AccessTokenForConnectionError: If the access token was not found or 
+            AccessTokenForConnectionError: If the access token was not found or
                 there was an issue requesting the access token.
         """
         state_data = await self._state_store.get(self._state_identifier, store_options)
@@ -646,7 +664,7 @@ class ServerClient(Generic[TStoreOptions]):
             state_data_dict = state_data.dict()
         else:
             state_data_dict = state_data or {}
-        
+
         # Find existing connection token
         connection_token_set = None
         if state_data_dict and len(state_data_dict["connection_token_sets"]) > 0:
@@ -654,11 +672,11 @@ class ServerClient(Generic[TStoreOptions]):
                 if ts.get("connection") == options["connection"]:
                     connection_token_set = ts
                     break
-  
+
         # If token is valid, return it
         if connection_token_set and connection_token_set.get("expires_at", 0) > time.time():
             return connection_token_set["access_token"]
-        
+
         # Check for refresh token
         if not state_data_dict or not state_data_dict.get("refresh_token"):
             raise AccessTokenForConnectionError(
@@ -671,70 +689,72 @@ class ServerClient(Generic[TStoreOptions]):
             "login_hint": options.get("login_hint"),
             "refresh_token": state_data_dict["refresh_token"]
         })
-        
+
         # Update state data with new token
-        updated_state_data = State.update_state_data_for_connection_token_set(options, state_data_dict, token_endpoint_response)
-        
+        updated_state_data = State.update_state_data_for_connection_token_set(
+            options, state_data_dict, token_endpoint_response)
+
         # Store updated state
         await self._state_store.set(self._state_identifier, updated_state_data, store_options)
-        
+
         return token_endpoint_response["access_token"]
-    
 
     async def logout(
-        self, 
+        self,
         options: Optional[LogoutOptions] = None,
         store_options: Optional[Dict[str, Any]] = None
     ) -> str:
         options = options or LogoutOptions()
-        
+
         # Delete the session from the state store
         await self._state_store.delete(self._state_identifier, store_options)
-        
+
         # Use the URL helper to create the logout URL.
-        logout_url = URL.create_logout_url(self._domain, self._client_id, options.return_to)
-        
+        logout_url = URL.create_logout_url(
+            self._domain, self._client_id, options.return_to)
+
         return logout_url
-    
+
     async def handle_backchannel_logout(
-        self, 
-        logout_token: str, 
+        self,
+        logout_token: str,
         store_options: Optional[Dict[str, Any]] = None
     ) -> None:
         """
         Handles backchannel logout requests.
-        
+
         Args:
             logout_token: The logout token sent by Auth0
             store_options: Options to pass to the state store
         """
         if not logout_token:
             raise BackchannelLogoutError("Missing logout token")
-        
+
         try:
             # Decode the token without verification
-            claims = jwt.decode(logout_token, options={"verify_signature": False})
-            
+            claims = jwt.decode(logout_token, options={
+                                "verify_signature": False})
+
             # Validate the token is a logout token
             events = claims.get("events", {})
             if "http://schemas.openid.net/event/backchannel-logout" not in events:
-                raise BackchannelLogoutError("Invalid logout token: not a backchannel logout event")
-            
+                raise BackchannelLogoutError(
+                    "Invalid logout token: not a backchannel logout event")
+
             # Delete sessions associated with this token
             logout_claims = LogoutTokenClaims(
                 sub=claims.get("sub"),
                 sid=claims.get("sid")
             )
-            
-            await self._state_store.delete_by_logout_token(logout_claims.dict(), store_options)
-            
-        except (jwt.JoseError, ValidationError) as e:
-            raise BackchannelLogoutError(f"Error processing logout token: {str(e)}")
-    
 
+            await self._state_store.delete_by_logout_token(logout_claims.dict(), store_options)
+
+        except (jwt.JoseError, ValidationError) as e:
+            raise BackchannelLogoutError(
+                f"Error processing logout token: {str(e)}")
 
     # Authlib Helpers
-    
+
     async def _build_link_user_url(
         self,
         connection: str,
@@ -747,15 +767,15 @@ class ServerClient(Generic[TStoreOptions]):
         """Build a URL for linking user accounts"""
         # Generate code challenge from verifier
         code_challenge = PKCE.generate_code_challenge(code_verifier)
-        
+
         # Get metadata if not already fetched
         if not hasattr(self, '_oauth_metadata'):
             self._oauth_metadata = await self._fetch_oidc_metadata(self._domain)
-        
+
         # Get authorization endpoint
-        auth_endpoint = self._oauth_metadata.get("authorization_endpoint", 
-                                                f"https://{self._domain}/authorize")
-        
+        auth_endpoint = self._oauth_metadata.get("authorization_endpoint",
+                                                 f"https://{self._domain}/authorize")
+
         # Build params
         params = {
             "client_id": self._client_id,
@@ -769,16 +789,16 @@ class ServerClient(Generic[TStoreOptions]):
             "scope": "openid link_account",
             "audience": "my-account"
         }
-        
+
         # Add connection scope if provided
         if connection_scope:
             params["requested_connection_scope"] = connection_scope
-        
+
         # Add any additional parameters
         if authorization_params:
             params.update(authorization_params)
         return URL.build_url(auth_endpoint, params)
-    
+
     async def _build_unlink_user_url(
         self,
         connection: str,
@@ -790,15 +810,15 @@ class ServerClient(Generic[TStoreOptions]):
         """Build a URL for unlinking user accounts"""
         # Generate code challenge from verifier
         code_challenge = PKCE.generate_code_challenge(code_verifier)
-        
+
         # Get metadata if not already fetched
         if not hasattr(self, '_oauth_metadata'):
             self._oauth_metadata = await self._fetch_oidc_metadata(self._domain)
-        
+
         # Get authorization endpoint
-        auth_endpoint = self._oauth_metadata.get("authorization_endpoint", 
-                                                f"https://{self._domain}/authorize")
-        
+        auth_endpoint = self._oauth_metadata.get("authorization_endpoint",
+                                                 f"https://{self._domain}/authorize")
+
         # Build params
         params = {
             "client_id": self._client_id,
@@ -814,26 +834,26 @@ class ServerClient(Generic[TStoreOptions]):
         # Add any additional parameters
         if authorization_params:
             params.update(authorization_params)
-        
+
         return URL.build_url(auth_endpoint, params)
-    
+
     async def backchannel_authentication(
         self,
         options: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
         Initiates backchannel authentication with Auth0.
-        
+
         This method starts a Client-Initiated Backchannel Authentication (CIBA) flow,
         which allows an application to request authentication from a user via a separate
         device or channel.
-        
+
         Args:
             options: Configuration options for backchannel authentication
-            
+
         Returns:
             Token response data from the backchannel authentication
-            
+
         Raises:
             ApiError: If the backchannel authentication fails
         """
@@ -841,56 +861,57 @@ class ServerClient(Generic[TStoreOptions]):
             # Fetch OpenID Connect metadata if not already fetched
             if not hasattr(self, '_oauth_metadata'):
                 self._oauth_metadata = await self._fetch_oidc_metadata(self._domain)
-            
+
             # Get the issuer from metadata
-            issuer = self._oauth_metadata.get("issuer") or f"https://{self._domain}/"
-            
+            issuer = self._oauth_metadata.get(
+                "issuer") or f"https://{self._domain}/"
+
             # Get backchannel authentication endpoint
-            backchannel_endpoint = self._oauth_metadata.get("backchannel_authentication_endpoint")
+            backchannel_endpoint = self._oauth_metadata.get(
+                "backchannel_authentication_endpoint")
             if not backchannel_endpoint:
                 raise ApiError(
-                    "configuration_error", 
+                    "configuration_error",
                     "Backchannel authentication is not supported by the authorization server"
                 )
-            
+
             # Get token endpoint
             token_endpoint = self._oauth_metadata.get("token_endpoint")
             if not token_endpoint:
                 raise ApiError(
-                    "configuration_error", 
+                    "configuration_error",
                     "Token endpoint is missing in OIDC metadata"
                 )
-            
-            sub = sub = options.get('login_hint', {}).get("sub")  
+
+            sub = sub = options.get('login_hint', {}).get("sub")
             if not sub:
                 raise ApiError(
                     "invalid_parameter",
                     "login_hint must contain a 'sub' field"
                 )
-                
+
             # Prepare login hint in the required format
             login_hint = json.dumps({
                 "format": "iss_sub",
                 "iss": issuer,
-                "sub": sub 
+                "sub": sub
             })
-            
+
             # The Request Parameters
             params = {
                 "client_id": self._client_id,
-                "scope": "openid profile email",  # DEFAULT_SCOPES 
+                "scope": "openid profile email",  # DEFAULT_SCOPES
                 "login_hint": login_hint,
             }
-            
-            
+
             # Add binding message if provided
             if options.get('binding_message'):
                 params["binding_message"] = options.get('binding_message')
-                
+
             # Add any additional authorization parameters
             if self._default_authorization_params:
                 params.update(self._default_authorization_params)
-                
+
             if options.get('authorization_params'):
                 params.update(options.get('authorization_params'))
 
@@ -906,20 +927,23 @@ class ServerClient(Generic[TStoreOptions]):
                     error_data = backchannel_response.json()
                     raise ApiError(
                         error_data.get("error", "backchannel_error"),
-                        error_data.get("error_description", "Backchannel authentication request failed")
+                        error_data.get(
+                            "error_description", "Backchannel authentication request failed")
                     )
-                    
+
                 backchannel_data = backchannel_response.json()
                 auth_req_id = backchannel_data.get("auth_req_id")
-                expires_in = backchannel_data.get("expires_in", 120)  # Default to 2 minutes
-                interval = backchannel_data.get("interval", 5)  # Default to 5 seconds
-                
+                expires_in = backchannel_data.get(
+                    "expires_in", 120)  # Default to 2 minutes
+                interval = backchannel_data.get(
+                    "interval", 5)  # Default to 5 seconds
+
                 if not auth_req_id:
                     raise ApiError(
-                        "invalid_response", 
+                        "invalid_response",
                         "Missing auth_req_id in backchannel authentication response"
                     )
-                
+
                 # Poll for token using the auth_req_id
                 token_params = {
                     "grant_type": "urn:openid:params:grant-type:ciba",
@@ -927,46 +951,48 @@ class ServerClient(Generic[TStoreOptions]):
                     "client_id": self._client_id,
                     "client_secret": self._client_secret
                 }
-                
+
                 # Calculate when to stop polling
                 end_time = time.time() + expires_in
-                
+
                 # Poll until we get a response or timeout
                 while time.time() < end_time:
                     # Make token request
                     token_response = await client.post(token_endpoint, data=token_params)
-                    
+
                     # Check for success (200 OK)
                     if token_response.status_code == 200:
                         # Success! Parse and return the token response
                         return token_response.json()
-                    
+
                     # Check for specific error that indicates we should continue polling
                     if token_response.status_code == 400:
                         error_data = token_response.json()
                         error = error_data.get("error")
-                        
+
                         # authorization_pending means we should keep polling
                         if error == "authorization_pending":
                             # Wait for the specified interval before polling again
                             await asyncio.sleep(interval)
                             continue
-                        
+
                         # Other errors should be raised
                         raise ApiError(
-                            error, 
-                            error_data.get("error_description", "Token request failed")
+                            error,
+                            error_data.get("error_description",
+                                           "Token request failed")
                         )
-                    
+
                     # Any other status code is an error
                     raise ApiError(
                         "token_error",
                         f"Unexpected status code: {token_response.status_code}"
                     )
-                
+
                 # If we get here, we've timed out
-                raise ApiError("timeout", "Backchannel authentication timed out")
-                
+                raise ApiError(
+                    "timeout", "Backchannel authentication timed out")
+
         except Exception as e:
             print("Caught exception:", type(e), e.args, repr(e))
             raise ApiError(
@@ -978,41 +1004,42 @@ class ServerClient(Generic[TStoreOptions]):
     async def get_token_by_refresh_token(self, options: Dict[str, Any]) -> Dict[str, Any]:
         """
         Retrieves a token by exchanging a refresh token.
-        
+
         Args:
             options: Dictionary containing the refresh token and any additional options.
                 Must include a 'refresh_token' key.
-        
+
         Raises:
             AccessTokenError: If there was an issue requesting the access token.
-        
+
         Returns:
             A dictionary containing the token response from Auth0.
         """
         refresh_token = options.get("refresh_token")
         if not refresh_token:
             raise MissingRequiredArgumentError("refresh_token")
-        
+
         try:
             # Ensure we have the OIDC metadata
             if not hasattr(self._oauth, "metadata") or not self._oauth.metadata:
                 self._oauth.metadata = await self._fetch_oidc_metadata(self._domain)
-            
+
             token_endpoint = self._oauth.metadata.get("token_endpoint")
             if not token_endpoint:
-                raise ApiError("configuration_error", "Token endpoint missing in OIDC metadata")
-            
+                raise ApiError("configuration_error",
+                               "Token endpoint missing in OIDC metadata")
+
             # Prepare the token request parameters
             token_params = {
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
                 "client_id": self._client_id,
             }
-            
+
             # Add scope if present in the original authorization params
             if "scope" in self._default_authorization_params:
                 token_params["scope"] = self._default_authorization_params["scope"]
-            
+
             # Exchange the refresh token for an access token
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -1020,22 +1047,24 @@ class ServerClient(Generic[TStoreOptions]):
                     data=token_params,
                     auth=(self._client_id, self._client_secret)
                 )
-                
+
                 if response.status_code != 200:
                     error_data = response.json()
                     raise ApiError(
                         error_data.get("error", "refresh_token_error"),
-                        error_data.get("error_description", "Failed to exchange refresh token")
+                        error_data.get("error_description",
+                                       "Failed to exchange refresh token")
                     )
-                
+
                 token_response = response.json()
-                
+
                 # Add required fields if they are missing
                 if "expires_in" in token_response and "expires_at" not in token_response:
-                    token_response["expires_at"] = int(time.time()) + token_response["expires_in"]
-                    
+                    token_response["expires_at"] = int(
+                        time.time()) + token_response["expires_in"]
+
                 return token_response
-                
+
         except Exception as e:
             if isinstance(e, ApiError):
                 raise
@@ -1044,19 +1073,19 @@ class ServerClient(Generic[TStoreOptions]):
                 "The access token has expired and there was an error while trying to refresh it.",
                 e
             )
-        
+
     async def get_token_for_connection(self, options: Dict[str, Any]) -> Dict[str, Any]:
         """
         Retrieves a token for a connection.
-        
+
         Args:
             options: Options for retrieving an access token for a connection.
                 Must include 'connection' and 'refresh_token' keys.
                 May optionally include 'login_hint'.
-        
+
         Raises:
             AccessTokenForConnectionError: If there was an issue requesting the access token.
-        
+
         Returns:
             Dictionary containing the token response with accessToken, expiresAt, and scope.
         """
@@ -1068,11 +1097,12 @@ class ServerClient(Generic[TStoreOptions]):
             # Ensure we have OIDC metadata
             if not hasattr(self._oauth, "metadata") or not self._oauth.metadata:
                 self._oauth.metadata = await self._fetch_oidc_metadata(self._domain)
-            
+
             token_endpoint = self._oauth.metadata.get("token_endpoint")
             if not token_endpoint:
-                raise ApiError("configuration_error", "Token endpoint missing in OIDC metadata")
-            
+                raise ApiError("configuration_error",
+                               "Token endpoint missing in OIDC metadata")
+
             # Prepare parameters
             params = {
                 "connection": options["connection"],
@@ -1082,7 +1112,7 @@ class ServerClient(Generic[TStoreOptions]):
                 "grant_type": GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN,
                 "client_id": self._client_id
             }
-            
+
             # Add login_hint if provided
             if "login_hint" in options and options["login_hint"]:
                 params["login_hint"] = options["login_hint"]
@@ -1090,26 +1120,28 @@ class ServerClient(Generic[TStoreOptions]):
             # Make the request
             async with httpx.AsyncClient() as client:
                 response = await client.post(
-                    token_endpoint, 
+                    token_endpoint,
                     data=params,
                     auth=(self._client_id, self._client_secret)
                 )
 
                 if response.status_code != 200:
-                    error_data = response.json() if response.headers.get("content-type") == "application/json" else {}
+                    error_data = response.json() if response.headers.get(
+                        "content-type") == "application/json" else {}
                     raise ApiError(
                         error_data.get("error", "connection_token_error"),
-                        error_data.get("error_description", f"Failed to get token for connection: {response.status_code}")
+                        error_data.get(
+                            "error_description", f"Failed to get token for connection: {response.status_code}")
                     )
-                
+
                 token_endpoint_response = response.json()
-                
+
                 return {
                     "access_token": token_endpoint_response.get("access_token"),
                     "expires_at": int(time.time()) + int(token_endpoint_response.get("expires_in", 3600)),
                     "scope": token_endpoint_response.get("scope", "")
                 }
-        
+
         except Exception as e:
             if isinstance(e, ApiError):
                 raise AccessTokenForConnectionError(


### PR DESCRIPTION
This pull request introduces enhancements to the `auth0_fastapi` and `auth0_server_python` packages, focusing on improving authorization parameter handling, code readability, and error handling. The most significant changes include the addition of support for pushed authorization requests, filtering out internal authorization parameters, and reformatting code for consistency.

### Enhancements to Authorization Handling:
* Updated `AuthClient.start_login` to support pushed authorization requests (`pushed_authorization_requests`) and filter out internal authorization parameters when constructing the `StartInteractiveLoginOptions`. This enables more flexible and secure login flows. (`[packages/auth0_fastapi/src/auth0_fastapi/auth/auth_client.pyL51-R66](diffhunk://#diff-47349150337ff64ab50bc31890bf9bcd92e4f22a546ee0af98b6a3b396e0e18eL51-R66)`)
* Added a new constant, `INTERNAL_AUTHORIZE_PARAMS`, in `ServerClient` to define parameters that should be excluded from external authorization requests. This ensures internal parameters are not unintentionally exposed. (`[[1]](diffhunk://#diff-ebd11b61dbbe85da67e630cf181505ec30e19e303c3a2ea32e45fb6568813933R45)`, `[[2]](diffhunk://#diff-ebd11b61dbbe85da67e630cf181505ec30e19e303c3a2ea32e45fb6568813933L131-R134)`)

### Code Readability Improvements:
* Reformatted multi-line statements in `auth_client.py` and `routes.py` for better readability and adherence to Python style guidelines. Examples include the initialization of `StatelessStateStore` and `CookieTransactionStore`, as well as raising `HTTPException` with formatted messages. (`[[1]](diffhunk://#diff-47349150337ff64ab50bc31890bf9bcd92e4f22a546ee0af98b6a3b396e0e18eR16-R37)`, `[[2]](diffhunk://#diff-47349150337ff64ab50bc31890bf9bcd92e4f22a546ee0af98b6a3b396e0e18eL130-R139)`, `[[3]](diffhunk://#diff-7a4031dab13a7f3d06e65d3b5d0bf9fe255462f9bd86f0f281a0db27523d9585R10-R22)`)

### Route Enhancements:
* Modified the `login` route in `routes.py` to extract and pass additional query parameters (`authorization_params`) to `AuthClient.start_login`, enabling dynamic authorization customization. (`[packages/auth0_fastapi/src/auth0_fastapi/server/routes.pyR37-R41](diffhunk://#diff-7a4031dab13a7f3d06e65d3b5d0bf9fe255462f9bd86f0f281a0db27523d9585R37-R41)`)