### PR TITLE
fix(auth0-fastapi): remove import from removed and unused util

### DIFF
--- a/packages/auth0_fastapi/src/auth0_fastapi/server/routes.py
+++ b/packages/auth0_fastapi/src/auth0_fastapi/server/routes.py
@@ -1,4 +1,4 @@
-from ..util import to_safe_redirect, create_route_url, merge_set_cookie_headers
+from ..util import to_safe_redirect, create_route_url
 from ..util import to_safe_redirect, create_route_url
 from fastapi import APIRouter, Request, Response, HTTPException, Depends, Query
 from fastapi.responses import RedirectResponse


### PR DESCRIPTION
This pull request includes a minor cleanup in the `packages/auth0_fastapi/src/auth0_fastapi/server/routes.py` file. The change removes an unused import to streamline the code.

Code cleanup:

* Removed the unused `merge_set_cookie_headers` import from `packages/auth0_fastapi/src/auth0_fastapi/server/routes.py`.