### PR TITLE
Add urn:ietf:params:oauth:token-type:access_token to token vault

### DIFF
--- a/packages/auth0_api_python/src/auth0_api_python/api_client.py
+++ b/packages/auth0_api_python/src/auth0_api_python/api_client.py
@@ -1,10 +1,11 @@
 import time
+import httpx
 from typing import Optional, List, Dict, Any
 
 from authlib.jose import JsonWebToken, JsonWebKey
 
 from .config import ApiClientOptions
-from .errors import MissingRequiredArgumentError, VerifyAccessTokenError
+from .errors import MissingRequiredArgumentError, VerifyAccessTokenError, GetTokenForConnectionError, ApiError
 from .utils import fetch_oidc_metadata, fetch_jwks, get_unverified_header
 
 class ApiClient:
@@ -126,3 +127,82 @@ class ApiClient:
                 raise VerifyAccessTokenError(f"Missing required claim: {rc}")
 
         return claims
+
+
+    async def get_token_for_connection(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Retrieves a token for a connection.
+
+        Args:
+            options: Options for retrieving an access token for a connection.
+                Must include 'connection' and 'access_token' keys.
+                May optionally include 'login_hint'.
+
+        Raises:
+            GetTokenForConnectionError: If there was an issue requesting the access token.
+            ApiError: If the token exchange endpoint returns an error.
+
+        Returns:
+            Dictionary containing the token response with accessToken, expiresAt, and scope.
+        """
+        # Constants
+        SUBJECT_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+        REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN = "http://auth0.com/oauth/token-type/federated-connection-access-token"
+        GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN = "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token"
+
+        connection = options.get("connection")
+        access_token = options.get("access_token")
+
+        if not connection:
+            raise MissingRequiredArgumentError("connection")
+
+        if not access_token:
+            raise MissingRequiredArgumentError("access_token")
+
+        associated_client = self.options.associated_client
+        if not associated_client:
+            raise GetTokenForConnectionError("You must configure the SDK with an associated_client to use get_token_for_connection.")
+
+        metadata = await self._discover()
+
+        token_endpoint = metadata.get("token_endpoint")
+        if not token_endpoint:
+            raise GetTokenForConnectionError("Token endpoint missing in OIDC metadata")
+
+        # Prepare parameters
+        params = {
+            "connection": connection,
+            "requested_token_type": REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN,
+            "grant_type": GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN,
+            "client_id": associated_client["client_id"],
+            "subject_token": access_token,
+            "subject_token_type": SUBJECT_TYPE_ACCESS_TOKEN,
+        }
+
+        # Add login_hint if provided
+        if "login_hint" in associated_client and associated_client["login_hint"]:
+            params["login_hint"] = options["login_hint"]
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                token_endpoint,
+                data=params,
+                auth=(associated_client["client_id"], associated_client["client_secret"])
+            )
+
+            if response.status_code != 200:
+                error_data = response.json() if response.headers.get(
+                    "content-type") == "application/json" else {}
+                raise ApiError(
+                    error_data.get("error", "connection_token_error"),
+                    error_data.get(
+                        "error_description", f"Failed to get token for connection: {response.status_code}")
+                )
+
+            token_endpoint_response = response.json()
+
+            return {
+                "access_token": token_endpoint_response.get("access_token"),
+                "expires_at": int(time.time()) + int(token_endpoint_response.get("expires_in", 3600)),
+                "scope": token_endpoint_response.get("scope", "")
+            }

--- a/packages/auth0_api_python/src/auth0_api_python/config.py
+++ b/packages/auth0_api_python/src/auth0_api_python/config.py
@@ -4,6 +4,9 @@ Configuration classes and utilities for auth0-api-python.
 
 from typing import Optional, Callable
 
+from auth0_api_python.errors import MissingRequiredArgumentError
+
+
 class ApiClientOptions:
     """
     Configuration for the ApiClient.
@@ -17,8 +20,15 @@ class ApiClientOptions:
         self,
         domain: str,
         audience: str,
-        custom_fetch: Optional[Callable[..., object]] = None
+        custom_fetch: Optional[Callable[..., object]] = None,
+        associated_client: Optional[dict] = None,
     ):
         self.domain = domain
         self.audience = audience
         self.custom_fetch = custom_fetch
+        self.associated_client = associated_client
+        if associated_client:
+            if not associated_client.get("client_id"):
+                raise MissingRequiredArgumentError("associated_client.client_id")
+            if not associated_client.get("client_secret"):
+                raise MissingRequiredArgumentError("associated_client.client_secret")

--- a/packages/auth0_api_python/src/auth0_api_python/errors.py
+++ b/packages/auth0_api_python/src/auth0_api_python/errors.py
@@ -19,3 +19,32 @@ class VerifyAccessTokenError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.name = self.__class__.__name__
+
+
+class GetTokenForConnectionError(Exception):
+    """Error raised when verifying the access token fails."""
+    code = "get_token_for_connection_error"
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.name = self.__class__.__name__
+
+
+class ApiError(Exception):
+    """
+    Error raised when an API request to Auth0 fails.
+    Contains details about the original error from Auth0.
+    """
+
+    def __init__(self, code: str, message: str, cause=None):
+        super().__init__(message)
+        self.code = code
+        self.cause = cause
+
+        # Extract additional error details if available
+        if cause:
+            self.error = getattr(cause, "error", None)
+            self.error_description = getattr(cause, "error_description", None)
+        else:
+            self.error = None
+            self.error_description = None

--- a/packages/auth0_server_python/src/auth0_server_python/error/__init__.py
+++ b/packages/auth0_server_python/src/auth0_server_python/error/__init__.py
@@ -47,10 +47,11 @@ class ApiError(Auth0Error):
 class AccessTokenError(Auth0Error):
     """Error raised when there's an issue with access tokens."""
     
-    def __init__(self, code: str, message: str):
+    def __init__(self, code: str, message: str, cause=None):
         super().__init__(message)
         self.code = code
         self.name = "AccessTokenError"
+        self.error = cause
 
 
 class MissingRequiredArgumentError(Auth0Error):
@@ -82,10 +83,11 @@ class BackchannelLogoutError(Auth0Error):
 class AccessTokenForConnectionError(Auth0Error):
     """Error when retrieving access tokens for a specific connection fails."""
     
-    def __init__(self, code: str, message: str):
+    def __init__(self, code: str, message: str, cause=None):
         super().__init__(message)
         self.code = code
         self.name = "AccessTokenForConnectionError"
+        self.error = cause
 
 class StartLinkUserError(Auth0Error):
     """


### PR DESCRIPTION
### Description

- Fix incorrect arguments on `AccessTokenForConnectionError`
- Input validation on `get_access_token_for_connection`
- Add support `urn:ietf:params:oauth:token-type:access_token` on `subject_token_type`

### References

https://oktawiki.atlassian.net/wiki/spaces/~6017c37320445000698e9629/pages/3663626850/Auth0+for+AI+Agents+-+GA+SDK+Support+Matrix

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
