### PR TITLE
fix(mfa): Make MfaRequiredError extend AccessTokenError and privatize encrypt_mfa_token

### DIFF
--- a/src/auth0_server_python/auth_server/mfa_client.py
+++ b/src/auth0_server_python/auth_server/mfa_client.py
@@ -105,7 +105,7 @@ class MfaClient:
     # MFA TOKEN ENCRYPTION / DECRYPTION
     # ============================================================================
 
-    def encrypt_mfa_token(
+    def _encrypt_mfa_token(
         self,
         raw_mfa_token: str,
         audience: str,

--- a/src/auth0_server_python/auth_server/server_client.py
+++ b/src/auth0_server_python/auth_server/server_client.py
@@ -1020,7 +1020,7 @@ class ServerClient(Generic[TStoreOptions]):
                 mfa_requirements = getattr(e, "mfa_requirements", None)
 
                 if raw_mfa_token:
-                    encrypted_token = self._mfa_client.encrypt_mfa_token(
+                    encrypted_token = self._mfa_client._encrypt_mfa_token(
                         raw_mfa_token=raw_mfa_token,
                         audience=audience or self.DEFAULT_AUDIENCE_STATE_KEY,
                         scope=merged_scope or "",

--- a/src/auth0_server_python/error/__init__.py
+++ b/src/auth0_server_python/error/__init__.py
@@ -275,7 +275,7 @@ class MfaVerifyError(MfaApiError):
         super().__init__("mfa_verify_error", message, cause)
 
 
-class MfaRequiredError(Auth0Error):
+class MfaRequiredError(AccessTokenError):
     """
     Error thrown when MFA step-up is required during token refresh.
 
@@ -291,11 +291,9 @@ class MfaRequiredError(Auth0Error):
         mfa_requirements=None,
         cause: Optional[Exception] = None
     ):
-        super().__init__(message)
-        self.code = "mfa_required"
+        super().__init__("mfa_required", message, cause)
         self.mfa_token = mfa_token
         self.mfa_requirements = mfa_requirements
-        self.cause = cause
 
 
 class MfaTokenExpiredError(Auth0Error):

--- a/src/auth0_server_python/tests/test_mfa_client.py
+++ b/src/auth0_server_python/tests/test_mfa_client.py
@@ -156,7 +156,7 @@ class TestMfaTokenEncryption:
             enroll=[{"type": "otp"}],
             challenge=[{"type": "oob"}]
         )
-        encrypted = client.encrypt_mfa_token(
+        encrypted = client._encrypt_mfa_token(
             raw_mfa_token="raw_token_123",
             audience="https://api.example.com",
             scope="openid profile",
@@ -175,7 +175,7 @@ class TestMfaTokenEncryption:
         client = _make_client()
         mocker.patch("auth0_server_python.auth_server.mfa_client.time.time",
                      return_value=1000)
-        encrypted = client.encrypt_mfa_token(
+        encrypted = client._encrypt_mfa_token(
             raw_mfa_token="raw",
             audience="aud",
             scope="scope"
@@ -194,7 +194,7 @@ class TestMfaTokenEncryption:
 
     def test_decrypt_tampered_token_raises(self):
         client = _make_client()
-        encrypted = client.encrypt_mfa_token(
+        encrypted = client._encrypt_mfa_token(
             raw_mfa_token="raw", audience="aud", scope="scope"
         )
         tampered = encrypted[:-5] + "XXXXX"
@@ -203,7 +203,7 @@ class TestMfaTokenEncryption:
 
     def test_encrypt_without_mfa_requirements(self):
         client = _make_client()
-        encrypted = client.encrypt_mfa_token(
+        encrypted = client._encrypt_mfa_token(
             raw_mfa_token="raw", audience="aud", scope="scope"
         )
         context = client.decrypt_mfa_token(encrypted)


### PR DESCRIPTION
## Changes
- **MfaRequiredError now extends AccessTokenError** instead of Auth0Error. Previously, `get_access_token()` could throw `MfaRequiredError` which would not be caught by existing `except AccessTokenError` handlers, silently breaking callers that rely on that pattern. Callers needing MFA-specific handling can catch `MfaRequiredError` before `AccessTokenError`.
- **Renamed `encrypt_mfa_token` to `_encrypt_mfa_token`** since it is only called internally by `ServerClient.get_access_token()`. `decrypt_mfa_token` remains public as callers need it to unwrap tokens from `MfaRequiredError`.