### PR TITLE
chore: add push trigger to debug RL scanner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Release
 
 on:
+  push:
+    branches:
+      - chore/debug-rl-scanner  # TEMPORARY: remove after RL scanner debugging
   workflow_dispatch:
 
 permissions:
@@ -9,7 +12,7 @@ permissions:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -53,7 +56,8 @@ jobs:
           PRODSEC_PYTHON_TOOLS_REPO: ${{ secrets.PRODSEC_PYTHON_TOOLS_REPO }}
 
   publish-pypi:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: false # TEMPORARY: disabled during RL scanner debugging — original condition below
+    # if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     name: "PyPI"
     runs-on: ubuntu-latest
     needs: rl-scanner


### PR DESCRIPTION
## Changes

- Add temporary push trigger on `chore/debug-rl-scanner` branch to test RL scanner workflow
- Add `github.event_name == 'push'` to rl-scanner job condition
- Disable `publish-pypi` job during debugging