### PR TITLE
docs: sync documentation with current API (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install auth0-server-python
 If you’re using Poetry:
 
 ```shell
-poetry install auth0-server-python
+poetry add auth0-server-python
 ```
 
 ### 2. Create the Auth0 SDK client
@@ -39,8 +39,8 @@ auth0 = ServerClient(
     client_id='<AUTH0_CLIENT_ID>',
     client_secret='<AUTH0_CLIENT_SECRET>',
     secret='<AUTH0_SECRET>',
-    authorization_params= {
-      redirect_uri: '<AUTH0_REDIRECT_URI>',
+    authorization_params={
+        "redirect_uri": '<AUTH0_REDIRECT_URI>',
     }
 )
 ```
@@ -82,8 +82,10 @@ app = FastAPI()
 
 
 @app.get("/auth/login")
-async def login(request: Request):
-    authorization_url = await auth0.start_interactive_login()
+async def login(request: Request, response: Response):
+    authorization_url = await auth0.start_interactive_login(
+        store_options={"request": request, "response": response}
+    )
     return RedirectResponse(url=authorization_url)
 ```
 
@@ -98,8 +100,11 @@ Here is an example of what this would look like in FastAPI, with `redirect_uri` 
 
 ```python
 @app.get("/auth/callback")
-async def callback(request: Request):
-    result = await auth0.complete_interactive_login(str(request.url))
+async def callback(request: Request, response: Response):
+    result = await auth0.complete_interactive_login(
+        str(request.url),
+        store_options={"request": request, "response": response}
+    )
     # Store session or set cookies as needed
     return RedirectResponse(url="/")
 ```
@@ -216,3 +221,10 @@ Please do not report security vulnerabilities on the public GitHub issue tracker
 <p align="center">
   This project is licensed under the MIT license. See the <a href="https://github.com/auth0/auth0-server-python/blob/main/LICENSE"> LICENSE</a> file for more info.
 </p>
+
+<!-- TODO: add usage example for logout -->
+<!-- TODO: add usage example for get_token_by_refresh_token -->
+<!-- TODO: add usage example for get_token_for_connection -->
+<!-- TODO: add usage example for backchannel_authentication -->
+<!-- TODO: add usage example for initiate_backchannel_authentication -->
+<!-- TODO: add usage example for backchannel_authentication_grant -->

--- a/examples/ConfigureStore.md
+++ b/examples/ConfigureStore.md
@@ -24,7 +24,12 @@ When you **start** or **complete** an Auth0 flow, you can pass a `store_options`
 
 ```python
 store_options = {"request": request, "response": response}
-await auth_client.start_login(app_state={"return_to": "/profile"}, store_options=store_options)
+from auth0_server_python.auth_types import StartInteractiveLoginOptions
+
+await server_client.start_interactive_login(
+    StartInteractiveLoginOptions(app_state={"return_to": "/profile"}),
+    store_options=store_options
+)
 ```
 ## 2.Stateless Store (All Data in Cookies)
 ### When to Use It
@@ -84,7 +89,7 @@ When users log in:
 @app.get("/auth/login")
 async def login(request: Request, response: Response):
     store_options = {"request": request, "response": response}
-    redirect_url = await request.app.state.auth_client.start_login(
+    redirect_url = await request.app.state.auth_client.start_interactive_login(
         store_options=store_options
     )
     return RedirectResponse(url=redirect_url)
@@ -395,7 +400,7 @@ Often you need `request` and `response` objects to set or clear cookies. In your
 @app.get("/auth/login")
 async def login(request: Request, response: Response):
     store_options = {"request": request, "response": response}
-    auth_url = await auth_client.start_login(
+    auth_url = await auth_client.start_interactive_login(
         store_options=store_options
     )
     return RedirectResponse(auth_url)
@@ -405,7 +410,7 @@ Likewise for logout or completing the login callback:
 @app.get("/auth/callback")
 async def callback(request: Request, response: Response):
     store_options = {"request": request, "response": response}
-    session_data = await auth_client.complete_login(
+    session_data = await auth_client.complete_interactive_login(
         str(request.url), 
         store_options=store_options
     )

--- a/examples/InteractiveLogin.md
+++ b/examples/InteractiveLogin.md
@@ -11,7 +11,7 @@ This guide covers how to customize the authorization parameters, pass custom app
 Interactive login begins by configuring a redirect_uri—the URL Auth0 will use to send the user back after authentication. For example, when instantiating your core `ServerClient`:
 
 ```python
-from auth_server.server_client import ServerClient
+from auth0_server_python.auth_server.server_client import ServerClient
 
 server_client = ServerClient(
     domain="YOUR_AUTH0_DOMAIN",
@@ -50,13 +50,17 @@ server_client = ServerClient(
 ### Dynamic Configuration Per Call
 You can also override or add parameters when calling `start_interactive_login()`:
 ```python
-authorization_url = await server_client.start_interactive_login({
-    "authorization_params": {
-        "scope": "openid profile email",
-        "audience": "urn:custom:api",
-        "foo": "bar"  # arbitrary custom parameter
-    }
-})
+from auth0_server_python.auth_types import StartInteractiveLoginOptions
+
+authorization_url = await server_client.start_interactive_login(
+    StartInteractiveLoginOptions(
+        authorization_params={
+            "scope": "openid profile email",
+            "audience": "urn:custom:api",
+            "foo": "bar"  # arbitrary custom parameter
+        }
+    )
+)
 ```
 > [!NOTE]
 > Any parameter specified here will override the corresponding global configuration.
@@ -67,9 +71,11 @@ The `app_state` parameter allows you to pass custom state (for example, a return
 
 ```python
 # Start interactive login with custom app state:
-authorize_url = await server_client.start_interactive_login({
-    "app_state": {"returnTo": "http://localhost:3000/dashboard"}
-})
+from auth0_server_python.auth_types import StartInteractiveLoginOptions
+
+authorize_url = await server_client.start_interactive_login(
+    StartInteractiveLoginOptions(app_state={"returnTo": "http://localhost:3000/dashboard"})
+)
 
 # Later, after completing login:
 result = await server_client.complete_interactive_login(callback_url)
@@ -84,9 +90,11 @@ print(result.get("app_state").get("returnTo"))  # Should output: http://localhos
 To enable PAR, simply set the flag in your interactive login options. When enabled, the SDK will send an HTTP POST request with the authorization parameters to the PAR endpoint (retrieved from OIDC metadata) and use the returned `request_uri` to build the final authorization URL.
 ```python
 # Enable PAR dynamically for a login call:
-authorization_url = await server_client.start_interactive_login({
-    "pushed_authorization_requests": True
-})
+from auth0_server_python.auth_types import StartInteractiveLoginOptions
+
+authorization_url = await server_client.start_interactive_login(
+    StartInteractiveLoginOptions(pushed_authorization_requests=True)
+)
 ```
 >[!IMPORTANT]
 > Using PAR requires that your Auth0 tenant is configured to support it. Refer to Auth0's documentation for details.
@@ -97,21 +105,22 @@ When using PAR, you can also supply Rich Authorization Request details by includ
 ```python
 import json
 
-authorization_url = await server_client.start_interactive_login({
-    "pushed_authorization_requests": True,
-    "authorization_params": {
-        "authorization_details": json.dumps([{
-            "type": "your_type",
-            "additional_field": "value"
-        }])
-    }
-})
+from auth0_server_python.auth_types import StartInteractiveLoginOptions
+
+authorization_url = await server_client.start_interactive_login(
+    StartInteractiveLoginOptions(
+        pushed_authorization_requests=True,
+        authorization_params={
+            "authorization_details": json.dumps([{
+                "type": "your_type",
+                "additional_field": "value"
+            }])
+        }
+    )
+)
 ```
 After completing the interactive login, the SDK will expose the `authorization_details` in the result:
 ```python
-import json
-
-authorization_url = await server_client.start_interactive_login({
 result = await server_client.complete_interactive_login(callback_url)
 print(result.get("authorization_details"))
 ```
@@ -122,7 +131,7 @@ print(result.get("authorization_details"))
 Most methods in the SDK accept a second argument called `store_options`. This dictionary should include the HTTP Request and Response objects (or equivalent) that the store uses to manage cookies and session data.
 ```python
 store_options = {"request": request, "response": response}
-authorization_url = await server_client.start_interactive_login({}, store_options=store_options)
+authorization_url = await server_client.start_interactive_login(store_options=store_options)
 ```
 This enables the SDK to correctly read and set cookies for session management.
 

--- a/examples/RetrievingData.md
+++ b/examples/RetrievingData.md
@@ -5,7 +5,7 @@
 The SDK's `get_user()` can be used to retrieve the current logged-in user:
 
 ```python
-user = await serverClient.get_user();
+user = await server_client.get_user()
 ```
 
 ### Passing Store Options
@@ -27,7 +27,7 @@ Read more above in [Configuring the Store](./ConfigureStore.md).
 The SDK's `get_session()` can be used to retrieve the current session data:
 
 ```python
-session = await serverClient.get_session();
+session = await server_client.get_session()
 ```
 
 ### Passing Store Options
@@ -244,7 +244,7 @@ access_token_for_google = await server_client.get_access_token_for_connection(co
 ```
 
 - `connection`: The connection for which an access token should be retrieved, e.g. `google-oauth2` for Google.
-- `loginHint`: Optional login hint to inform which connection account to use, can be useful when multiple accounts for the connection exist for the same user. 
+- `login_hint`: Optional login hint to inform which connection account to use, can be useful when multiple accounts for the connection exist for the same user. 
 
 The SDK will cache the token internally, and return it from the cache when not expired. When no token is found in the cache, or the token is expired, calling `get_access_token_for_connection()` will call Auth0 to retrieve a new token and update the cache.
 


### PR DESCRIPTION
## Summary

Automated documentation drift fix. 15 findings addressed (2 P1 · 7 P2 · 6 P3-D stubs).

## Changes

- `README.md` — fix `poetry install` → `poetry add` (P1, wrong Poetry subcommand)
- `README.md` — fix unquoted dict key `redirect_uri:` → `"redirect_uri":` (P1, Python `NameError` on copy-paste)
- `README.md` — add missing `store_options` to login/callback route examples (P2)
- `README.md` — add 6 P3-D TODO stubs for undocumented public methods (`logout`, `get_token_by_refresh_token`, `get_token_for_connection`, `backchannel_authentication`, `initiate_backchannel_authentication`, `backchannel_authentication_grant`)
- `examples/InteractiveLogin.md` — fix import `from auth_server.server_client` → `from auth0_server_python.auth_server.server_client` (P2)
- `examples/InteractiveLogin.md` — replace raw `dict` calls with `StartInteractiveLoginOptions(...)` in sections 2, 3, 4, 5, 6 (P2, `AttributeError` in typed integrations)
- `examples/InteractiveLogin.md` — fix broken/unclosed code block in section 5 RAR example (P2, `SyntaxError`)
- `examples/ConfigureStore.md` — replace `start_login()`/`complete_login()` with `start_interactive_login()`/`complete_interactive_login()` (P2, wrong method names for `ServerClient`)
- `examples/RetrievingData.md` — remove trailing semicolons from Python code examples (P3)
- `examples/RetrievingData.md` — fix `loginHint` → `login_hint` in option description (P3)

<details>
<summary>Full Drift Report</summary>

| # | Severity | File | Issue |
|---|---|---|---|
| 1 | P1 | `README.md` | `poetry install auth0-server-python` is wrong — should be `poetry add` |
| 2 | P1 | `README.md` | Unquoted dict key `redirect_uri:` causes `NameError` in Python |
| 3 | P2 | `README.md` | Login/callback examples omit `store_options` — silently breaks cookie-based stores |
| 4 | P2 | `examples/InteractiveLogin.md` | Wrong import: `from auth_server.server_client` missing package prefix |
| 5 | P2 | `examples/InteractiveLogin.md` | `start_interactive_login({...})` with raw dict — must use `StartInteractiveLoginOptions` |
| 6 | P2 | `examples/InteractiveLogin.md` | Unclosed brace in section 5 RAR code block causes `SyntaxError` |
| 7 | P2 | `examples/ConfigureStore.md` | `start_login()`/`complete_login()` are non-existent method names on `ServerClient` |
| 8 | P3 | `examples/RetrievingData.md` | Trailing semicolons on `get_user();` and `get_session();` + camelCase `serverClient` |
| 9 | P3 | `examples/RetrievingData.md` | `loginHint` should be `login_hint` (snake_case) |
| 10 | P3-D | `README.md` stub | `logout` — no documentation in any file |
| 11 | P3-D | `README.md` stub | `get_token_by_refresh_token` — no documentation in any file |
| 12 | P3-D | `README.md` stub | `get_token_for_connection` — no documentation in any file |
| 13 | P3-D | `README.md` stub | `backchannel_authentication` — mid-level CIBA method undocumented |
| 14 | P3-D | `README.md` stub | `initiate_backchannel_authentication` — low-level CIBA primitive undocumented |
| 15 | P3-D | `README.md` stub | `backchannel_authentication_grant` — low-level CIBA primitive undocumented |

</details>

---
🤖 Generated with [syncing-docs](https://github.com/atko-cic/claude-marketplace) skill
