### PR TITLE
fix: reject blank organization before actor resolution in session transfer token request

### DIFF
--- a/examples/CustomTokenExchange.md
+++ b/examples/CustomTokenExchange.md
@@ -201,7 +201,7 @@ from auth0_server_python.error import CustomTokenExchangeError
 result = await auth0.request_session_transfer_token(
     subject_token=subject_token,            # your proof of which customer to impersonate
     subject_token_type="urn:acme:customer-subject",
-    organization=None,                      # optional; forwarded to the redirect
+    organization=None,                      # optional, sent on the mint request (separate from the redirect)
     store_options={"request": request, "response": None},
 )
 
@@ -216,7 +216,14 @@ return RedirectResponse(redirect_url)       # your framework performs the redire
 
 > **NOTE**: An actor is mandatory - an STT is only issued when the Action set one. By default the SDK sources the actor from the logged-in agent's session ID token, refreshing it when expired. If the agent is not logged in (no usable session ID token and none can be refreshed), the call fails client-side with `ACTOR_UNAVAILABLE` before any network request.
 
-> **NOTE**: To use your own actor token instead of the session, pass `actor_token` (and optionally `actor_token_type`, which defaults to the ID token URN). An explicit `actor_token` takes precedence and the session is not read at all. It must be an **unexpired, asymmetrically-signed JWT** (RS256 or PS256) - an Auth0 session ID token satisfies this; an HS256 or expired token is rejected by the server.
+> **NOTE**: To use your own actor token instead of the session, pass `actor_token` (and optionally `actor_token_type`, which defaults to the ID token URN). An explicit `actor_token` takes precedence and the session is not read at all. When `actor_token_type` is the ID token URN (the default), Auth0 validates the token, so it must be:
+>
+> - Signed with RS256 or PS256 (HS256 is rejected, it uses a shared secret).
+> - Unexpired, and carrying `sub`, `iss`, `exp`, and `iat`.
+> - Issued to the same client making the exchange (its `aud` must be that client's ID).
+> - Belonging to a user who still exists and is not blocked.
+>
+> An Auth0 ID token from the agent's own session on this client satisfies all of these. A token that fails any of them is rejected by the server.
 >
 > ```python
 > result = await auth0.request_session_transfer_token(
@@ -229,7 +236,7 @@ return RedirectResponse(redirect_url)       # your framework performs the redire
 
 ### Target: forward the STT to `/authorize`
 
-On the target, the STT rides through your normal login. `start_interactive_login` forwards arbitrary authorization parameters to `/authorize`, so your login route just passes `session_transfer_token` (and `organization`, when the STT was issued in an org context) straight through:
+On the target, the STT rides through your normal login. `start_interactive_login` forwards arbitrary authorization parameters to `/authorize`, so your login route just passes `session_transfer_token` (and `organization`, when you want the target login org-scoped) straight through:
 
 ```python
 from auth0_server_python.auth_types import StartInteractiveLoginOptions
@@ -237,7 +244,7 @@ from auth0_server_python.auth_types import StartInteractiveLoginOptions
 url = await auth0.start_interactive_login(
     StartInteractiveLoginOptions(authorization_params={
         "session_transfer_token": request.query_params["session_transfer_token"],
-        # "organization": org,   # when the STT was issued in an org context
+        # "organization": org,   # when you want the target login org-scoped
     }),
     store_options={"request": request, "response": None},
 )

--- a/src/auth0_server_python/auth_server/server_client.py
+++ b/src/auth0_server_python/auth_server/server_client.py
@@ -2763,6 +2763,7 @@ class ServerClient(Generic[TStoreOptions]):
 
         Raises:
             CustomTokenExchangeError: If no actor can be resolved or the exchange fails
+            InvalidArgumentError: If organization is provided but blank
         """
         try:
             # Validate the subject up front - before any session read/refresh/network.

--- a/src/auth0_server_python/auth_server/server_client.py
+++ b/src/auth0_server_python/auth_server/server_client.py
@@ -2777,6 +2777,9 @@ class ServerClient(Generic[TStoreOptions]):
                     "subject_token_type cannot be empty or whitespace-only"
                 )
 
+            if organization is not None and not organization.strip():
+                raise InvalidArgumentError("organization", "organization must not be blank")
+
             actor_token, actor_token_type = await self._resolve_actor_token(
                 actor_token, actor_token_type, store_options)
 
@@ -2805,7 +2808,7 @@ class ServerClient(Generic[TStoreOptions]):
                 token_type=response.token_type,
                 scope=response.scope,
             )
-        except (CustomTokenExchangeError, ApiError):
+        except (CustomTokenExchangeError, InvalidArgumentError, ApiError):
             raise
         except Exception as e:
             raise CustomTokenExchangeError(

--- a/src/auth0_server_python/tests/test_server_client.py
+++ b/src/auth0_server_python/tests/test_server_client.py
@@ -4228,6 +4228,20 @@ def test_build_session_transfer_redirect_rejects_blank_organization():
 
 
 @pytest.mark.asyncio
+async def test_request_session_transfer_token_rejects_blank_organization(mocker):
+    """A blank organization is rejected before the actor is resolved or any request is sent."""
+    client, post_mock = _stt_client(mocker)
+
+    with pytest.raises(InvalidArgumentError):
+        await client.request_session_transfer_token(
+            subject_token="subj", subject_token_type="urn:acme:sub", actor_token="a",
+            organization="   ",
+        )
+
+    post_mock.post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_request_session_transfer_token_surfaces_server_issued_token_type(mocker):
     """A non-STT issued_token_type is surfaced verbatim, never fabricated as the STT URN."""
     client, _ = _stt_client(mocker, exchange_response={

--- a/src/auth0_server_python/tests/test_server_client.py
+++ b/src/auth0_server_python/tests/test_server_client.py
@@ -4257,7 +4257,7 @@ async def test_request_session_transfer_token_rejects_blank_organization_before_
     """A blank organization is rejected before the expired session is refreshed or persisted."""
     client, post_mock = _stt_client(mocker)
     client._state_store.get.return_value = {"id_token": "stale", "refresh_token": "rt"}
-    usable = mocker.patch.object(client, "_is_id_token_usable", side_effect=[False, True])
+    usable = mocker.patch.object(client, "_is_id_token_usable")
     refresh = mocker.patch.object(client, "get_token_by_refresh_token")
 
     with pytest.raises(InvalidArgumentError):

--- a/src/auth0_server_python/tests/test_server_client.py
+++ b/src/auth0_server_python/tests/test_server_client.py
@@ -4228,16 +4228,47 @@ def test_build_session_transfer_redirect_rejects_blank_organization():
 
 
 @pytest.mark.asyncio
-async def test_request_session_transfer_token_rejects_blank_organization(mocker):
-    """A blank organization is rejected before the actor is resolved or any request is sent."""
+async def test_request_session_transfer_token_forwards_organization_on_mint(mocker):
+    """A provided organization is forwarded onto the mint request."""
     client, post_mock = _stt_client(mocker)
+
+    await client.request_session_transfer_token(
+        subject_token="subj", subject_token_type="urn:acme:sub", actor_token="a",
+        organization="org_abc123",
+    )
+
+    assert post_mock.post.call_args[1]["data"]["organization"] == "org_abc123"
+
+
+@pytest.mark.asyncio
+async def test_request_session_transfer_token_omits_organization_when_absent(mocker):
+    """No organization passed → the parameter is absent from the mint request, not empty."""
+    client, post_mock = _stt_client(mocker)
+
+    await client.request_session_transfer_token(
+        subject_token="subj", subject_token_type="urn:acme:sub", actor_token="a",
+    )
+
+    assert "organization" not in post_mock.post.call_args[1]["data"]
+
+
+@pytest.mark.asyncio
+async def test_request_session_transfer_token_rejects_blank_organization_before_refresh(mocker):
+    """A blank organization is rejected before the expired session is refreshed or persisted."""
+    client, post_mock = _stt_client(mocker)
+    client._state_store.get.return_value = {"id_token": "stale", "refresh_token": "rt"}
+    usable = mocker.patch.object(client, "_is_id_token_usable", side_effect=[False, True])
+    refresh = mocker.patch.object(client, "get_token_by_refresh_token")
 
     with pytest.raises(InvalidArgumentError):
         await client.request_session_transfer_token(
-            subject_token="subj", subject_token_type="urn:acme:sub", actor_token="a",
+            subject_token="subj", subject_token_type="urn:acme:sub",
             organization="   ",
         )
 
+    refresh.assert_not_called()
+    usable.assert_not_called()
+    client._state_store.set.assert_not_called()
     post_mock.post.assert_not_called()
 
 


### PR DESCRIPTION
### 📋 Changes

This PR moves the blank-`organization` check in `request_session_transfer_token` ahead of actor resolution, so a request that cannot succeed no longer refreshes and persists the agent session first. It also corrects the Session Transfer Token section of `examples/CustomTokenExchange.md` where the docs described behavior that did not match the implementation or the platform.

#### 🔧 API Changes
- `request_session_transfer_token` now rejects a blank (empty or whitespace-only) `organization` with `InvalidArgumentError` before the actor is resolved, so an expired agent session ID token is no longer refreshed and re-persisted on a request that cannot succeed. This matches the up-front check already in `build_session_transfer_redirect`.

#### 📖 Documentation
- `organization` on the mint is sent on the token exchange request, not forwarded to the redirect; corrected the inline comment that said otherwise
- The actor-token crypto requirement now states it applies when `actor_token_type` is the ID token URN (the default), and lists the `aud`-must-match-this-client and user-still-exists-and-not-blocked checks
- The redirect `organization` is no longer described as conditional on how the STT was minted; pass it when you want the target login org-scoped, the same as any other org-scoped login

#### 🧪 Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).