### PR TITLE
docs: add repo conventions section to code-style reference

### DIFF
--- a/references/code-style.md
+++ b/references/code-style.md
@@ -1,17 +1,17 @@
 # Code Style
 
-Linter config: `.ruff.toml` (repo root — not `[tool.ruff]` in `pyproject.toml`).
+Linter config: `.ruff.toml` (repo root - not `[tool.ruff]` in `pyproject.toml`).
 
 ## Enforced rule sets
 
-`select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "PLC0415"]` — pycodestyle, pyflakes, isort,
+`select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "PLC0415"]` - pycodestyle, pyflakes, isort,
 bugbear, comprehensions, pyupgrade, **bandit (security)**, and no-import-outside-top-level.
 
-`ignore = ["E501", "B904", "S101", "S105", "S106"]` — line length is not enforced despite
-`line-length = 100`; `raise ... from` is optional; `assert` and hardcoded-password-string warnings are
+`ignore = ["E501", "B904", "S101", "S105", "S106"]` - line length is not enforced despite
+`line-length = 100`. `raise ... from` is optional. `assert` and hardcoded-password-string warnings are
 off (for tests and for kwargs like `client_secret=`).
 
-`target-version = "py39"` — pyupgrade will not rewrite to 3.10+ syntax, and must not.
+`target-version = "py39"` - pyupgrade will not rewrite to 3.10+ syntax, and must not.
 
 ## Naming
 
@@ -29,7 +29,7 @@ off (for tests and for kwargs like `client_secret=`).
 Two-step flows name themselves: `start_*` / `complete_*` (`start_link_user` → `complete_link_user`),
 and challenge-then-exchange flows use `*_challenge` → `signin_with_*`.
 
-## ✅ Good — the dominant public-method shape
+## ✅ Good - the dominant public-method shape
 
 ```python
 async def passkey_login_challenge(
@@ -71,11 +71,11 @@ async def passkey_login_challenge(
 
 What makes it conform:
 
-- `async` + keyword-only-ish optional params, every one typed, `Optional[...]` (not `X | None` — py39 floor)
-- returns a **Pydantic model**, validated via `model_validate` — never a raw `dict`
+- `async` + keyword-only-ish optional params, every one typed, `Optional[...]` (not `X | None` - py39 floor)
+- returns a **Pydantic model**, validated via `model_validate` - never a raw `dict`
 - `store_options` threaded through so MCD domain resolution works
 - Google-style docstring with `Args` / `Returns` / `Raises`
-- `async with self._get_http_client()` — the telemetry-carrying client, never a bare `httpx.AsyncClient`
+- `async with self._get_http_client()` - the telemetry-carrying client, never a bare `httpx.AsyncClient`
 - catch-all re-raises the SDK's own typed errors untouched, then wraps anything unexpected in a typed
   error with a code, chaining the cause
 
@@ -98,32 +98,32 @@ can mistake for "no passkey" instead of "request failed", and an unvalidated `di
 
 ## Patterns in use
 
-- **Generic client over the store type** — `ServerClient(Generic[TStoreOptions])`; store implementations
+- **Generic client over the store type** - `ServerClient(Generic[TStoreOptions])`; store implementations
   subclass `StateStore` / `TransactionStore` from `store/abstract.py` (template method: the ABC owns
   `encrypt`/`decrypt`, subclasses own `set`/`get`/`delete`)
-- **Sub-client composition** — `ServerClient` owns `MfaClient` and `MyAccountClient`; MFA is exposed
+- **Sub-client composition** - `ServerClient` owns `MfaClient` and `MyAccountClient`. MFA is exposed
   through the read-only `mfa` property, and connected-accounts calls delegate to `_my_account_client`
-- **`httpx.Auth` strategies** — `BearerAuth` and `DPoPAuth` in `auth_schemes/`, selected by a
+- **`httpx.Auth` strategies** - `BearerAuth` and `DPoPAuth` in `auth_schemes/`, selected by a
   `_make_auth(access_token, dpop_key)` helper. Add a new scheme as another `httpx.Auth`, not as
   inline header-setting.
-- **Pydantic models as the wire contract** — everything in `auth_types/__init__.py`; caller-supplied
+- **Pydantic models as the wire contract** - everything in `auth_types/__init__.py`; caller-supplied
   enums are `Literal[...]` while server-returned fields stay `str` so a new Auth0 factor type doesn't
   fail closed
-- **Flat typed error hierarchy** — every error subclasses `Auth0Error` and carries a stable `code`;
-  code enumeration classes (`AccessTokenErrorCode`, `PasskeyErrorCode`, …) hold the string constants
-- **PEP 562 module `__getattr__`** for deprecated public aliases (`auth_types._DEPRECATED_ALIASES`) —
+- **Flat typed error hierarchy** - every error subclasses `Auth0Error` and carries a stable `code`.
+  Code enumeration classes (`AccessTokenErrorCode`, `PasskeyErrorCode`, …) hold the string constants
+- **PEP 562 module `__getattr__`** for deprecated public aliases (`auth_types._DEPRECATED_ALIASES`) -
   the import keeps working and emits a `DeprecationWarning`. Follow this when retiring a public name.
-- **Section banners** — long modules are divided with `# ====== SECTION ======` comment blocks;
-  keep new methods inside the matching section and preserve existing declaration order.
-- **Deliberate placement, even without banners** — in a file with no section banners, put a new
+- **Section banners** - long modules are divided with `# ====== SECTION ======` comment blocks.
+  Keep new methods inside the matching section and preserve existing declaration order.
+- **Deliberate placement, even without banners** - in a file with no section banners, put a new
   method/class/function next to the related code it belongs with, or append it at the end of the
   file/class. Never insert one at an arbitrary position just because it compiles there.
 
 ## Comments
 
-Code is largely self-documenting; comments are reserved for *why* — a protocol citation
-(`# RFC 9449 §8.2 — server-nonce retry`), a non-obvious security decision (`# NFC-normalize before
-comparison...`), or an intentional omission (`# redirect_uri is intentionally excluded — in MCD mode
+Code is largely self-documenting. Comments are reserved for *why* - a protocol citation
+(`# RFC 9449 §8.2 - server-nonce retry`), a non-obvious security decision (`# NFC-normalize before
+comparison...`), or an intentional omission (`# redirect_uri is intentionally excluded - in MCD mode
 it is built dynamically`). Don't add comments that restate the code.
 
 ## Repo Conventions

--- a/references/code-style.md
+++ b/references/code-style.md
@@ -125,3 +125,39 @@ Code is largely self-documenting; comments are reserved for *why* — a protocol
 (`# RFC 9449 §8.2 — server-nonce retry`), a non-obvious security decision (`# NFC-normalize before
 comparison...`), or an intentional omission (`# redirect_uri is intentionally excluded — in MCD mode
 it is built dynamically`). Don't add comments that restate the code.
+
+## Repo Conventions
+
+Enforced on every change (code, tests, docs, commit messages). A change that
+violates one is not done.
+
+1. **Helpers stay grouped.** Keep private and internal helpers together in one
+   place. Never interleave a helper between the public API methods of a flow -
+   no public method immediately followed by its own private helper. A reader
+   scanning the public surface must not trip over internals.
+2. **New public API goes last.** The public API for a new, independent feature
+   is added at the end of the class, so existing flows stay contiguous and read
+   top to bottom. Insert new methods without reordering existing declarations.
+   Keep the diff minimal.
+3. **Standard docstring format.** A crisp one-line description of what the
+   function does, then `Args`, then `Returns`/`Raises`. No multi-line prose
+   restating the code or narrating design rationale - that belongs in the PR
+   description.
+4. **Plain hyphens only.** No em or en dashes anywhere in prose: comments,
+   docstrings, commit messages, Markdown docs. Use a plain `-`.
+5. **No semicolon clause-splicing.** Never join two independent clauses with a
+   semicolon. Split them into separate sentences.
+6. **No narrating comments.** Never add a comment that restates a
+   self-explanatory line. A comment is earned only by a non-obvious WHY: a
+   hidden constraint, a subtle invariant, or a security rationale a reader could
+   not infer from the code.
+7. **No internal references.** No pointer a future reader cannot resolve from
+   the code alone: ticket numbers, planning-doc IDs, design-doc paths, or
+   internal links.
+8. **Trim comments to the minimum.** Default to few or none. An earned comment
+   is a single sharp line, focused and to the point, carrying only what is
+   valuable to the developer. Multi-line comments are exceptional and must
+   justify themselves.
+9. **Plain, direct voice.** No conversational filler and no cross-implementation
+   references ("same as the Node SDK"). State the behavior or invariant directly
+   in simple, clear English.

--- a/references/code-style.md
+++ b/references/code-style.md
@@ -135,10 +135,12 @@ violates one is not done.
    place. Never interleave a helper between the public API methods of a flow -
    no public method immediately followed by its own private helper. A reader
    scanning the public surface must not trip over internals.
-2. **New public API goes last.** The public API for a new, independent feature
-   is added at the end of the class, so existing flows stay contiguous and read
-   top to bottom. Insert new methods without reordering existing declarations.
-   Keep the diff minimal.
+2. **New public API goes last.** A pre-existing `# ==== SECTION ====` banner
+   takes precedence: place a new method in its matching section (see "Section
+   banners" above). Only when no matching section exists is a new, independent
+   feature's public API added at the end of the class, so existing flows stay
+   contiguous and read top to bottom. Either way, insert new methods without
+   reordering existing declarations, and keep the diff minimal.
 3. **Standard docstring format.** A crisp one-line description of what the
    function does, then `Args`, then `Returns`/`Raises`. No multi-line prose
    restating the code or narrating design rationale - that belongs in the PR


### PR DESCRIPTION
**Added**

- doc: Added a "Repo Conventions" section to `references/code-style.md` listing the nine rules enforced on every change (code, tests, docs, commit messages), helper grouping, new-public-API placement, docstring format, plain hyphens, no semicolon splicing, comment discipline, no internal references, comment trimming, and plain direct voice.

### Testing

Documentation only change. No code paths, public API, or configuration are affected, so there is nothing to unit or integration test. Reviewers can verify by reading the new section for accuracy against the existing repo conventions.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors